### PR TITLE
feat: reLayoutLayers for pages

### DIFF
--- a/demo/new/layout.ts
+++ b/demo/new/layout.ts
@@ -1,0 +1,39 @@
+import * as path from "path";
+import { JSONPack, Page, Layer } from "../../src";
+
+const targetPath = "temp/new/layout";
+const newPackPath = path.join(targetPath, "layout");
+
+(async () => {
+  try {
+    const layers = [];
+    for (let i = 0; i < 100; i++) {
+      const newLayer = new Layer();
+      newLayer.updateProps({
+        data: {
+          name: `layer ${i}`,
+          frame: {
+            _class: "rect",
+            constrainProportions: false,
+            height: Math.floor(Math.random() * Math.floor(700)),
+            width: Math.floor(Math.random() * Math.floor(400)),
+            x: Math.floor(Math.random() * Math.floor(50)),
+            y: Math.floor(Math.random() * Math.floor(50)),
+          },
+        },
+      } as any);
+
+      layers.push(newLayer.toSketchJSON());
+    }
+
+    const newPage = new Page({ layers } as any);
+    newPage.reLayoutLayers();
+
+    const newPack = new JSONPack({ pages: [newPage] } as any);
+
+    await newPack.write(newPackPath);
+    await newPack.zip(path.join(path.dirname(newPackPath), "layout.sketch"));
+  } catch (error) {
+    throw error;
+  }
+})();

--- a/demo/new/new.ts
+++ b/demo/new/new.ts
@@ -2,4 +2,4 @@ import { JSONPack } from "../../src";
 
 const pack = new JSONPack();
 
-pack.writeSync("temp/new");
+pack.writeSync("temp/new/new");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sketch-json-api",
-  "version": "0.1.0-alpha.14",
+  "version": "0.1.0-alpha.15",
   "description": "",
   "main": "dist/src/index.js",
   "scripts": {

--- a/src/structures/Layer.ts
+++ b/src/structures/Layer.ts
@@ -1,6 +1,7 @@
 import { v4 } from "uuid";
 
 import SketchType from "../types";
+import { assignDeep } from "../utils";
 
 export interface LayerConstrOpts {
   class: SketchType.LayerClass;
@@ -127,12 +128,16 @@ export class Layer {
   updateProps(options?: any) {
     Object.keys(options).forEach((prop) => {
       if (this.hasOwnProperty(prop)) {
-        this[prop as keyof this] = options[prop];
+        this[prop as keyof this] = assignDeep(
+          {},
+          this[prop as keyof this],
+          options[prop]
+        );
       }
     });
   }
 
   toSketchJSON(): SketchType.Layer {
-    return this.data;
+    return JSON.parse(JSON.stringify(this.data));
   }
 }

--- a/src/structures/Page.ts
+++ b/src/structures/Page.ts
@@ -171,4 +171,37 @@ export class Page {
     });
     return filteredLayers;
   }
+
+  reLayoutLayers() {
+    let yMark = 0;
+    const Y_Margin = 20;
+    const Y_MAX = 2000;
+
+    let xMark = 0;
+    const X_Margin = 100;
+    let localMaxWidth = 0;
+
+    this.layers.forEach((layer, i) => {
+      const { height, width } = layer.frame;
+
+      if (width > localMaxWidth) {
+        localMaxWidth = width;
+      }
+
+      let layerTop = yMark + Y_Margin;
+      let layerBottom = layerTop + height;
+
+      if (layerBottom > Y_MAX) {
+        layerTop = 0;
+        layerBottom = height;
+        xMark += localMaxWidth + X_Margin;
+        localMaxWidth = width;
+      }
+
+      this.layers[i].frame.y = layerTop;
+      yMark = layerBottom;
+
+      this.layers[i].frame.x = xMark;
+    });
+  }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,3 +19,4 @@ export function makeid(length: number): string {
 }
 
 export * from "./fs-custom";
+export * from "./object";

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,0 +1,25 @@
+export function isObject(item: any) {
+  return item && typeof item === "object" && !Array.isArray(item);
+}
+
+export function assignDeep(target: any, ...sources: any): any {
+  if (!sources.length) return target;
+  const source = sources.shift();
+
+  if (isObject(target) && isObject(source)) {
+    for (const key in source) {
+      if (isObject(source[key])) {
+        if (!target[key]) {
+          Object.assign(target, { [key]: {} });
+        } else {
+          target[key] = Object.assign({}, target[key]);
+        }
+        assignDeep(target[key], source[key]);
+      } else {
+        Object.assign(target, { [key]: source[key] });
+      }
+    }
+  }
+
+  return assignDeep(target, ...sources);
+}


### PR DESCRIPTION
* relayout layers for pages so that layers would not overlap in generated Sketch file.
* fix: shallow clone problems in Layer
* util: assignDeep - recursive Object assign
* demo: new/layout
* 0.1.0-alpha.15